### PR TITLE
settings: 支持图片直链域名

### DIFF
--- a/backend/controllers/ImageAPI.go
+++ b/backend/controllers/ImageAPI.go
@@ -119,7 +119,7 @@ func GetRandomImages(c *gin.Context) {
 			return
 		}
 
-		publicURL := applyPublicImageURL(setting, images[0].Storage, images[0].Url)
+		publicURL := applyPublicImageURL(setting, images[0].Storage, images[0].BucketId, images[0].Url)
 		if strings.HasPrefix(publicURL, "http://") || strings.HasPrefix(publicURL, "https://") {
 			c.Redirect(http.StatusFound, publicURL)
 			return
@@ -140,7 +140,7 @@ func GetRandomImages(c *gin.Context) {
 		return
 	}
 	for _, img := range images {
-		fullUrl := buildImageResponseURL(c, setting, img.Storage, img.Url)
+		fullUrl := buildImageResponseURL(c, setting, img.Storage, img.BucketId, img.Url)
 		respData = append(respData, RandomImageResponse{
 			Image: img.FileName,
 			Url:   fullUrl,

--- a/backend/controllers/ImageAPI.go
+++ b/backend/controllers/ImageAPI.go
@@ -6,6 +6,7 @@ import (
 	"oneimg/backend/database"
 	"oneimg/backend/models"
 	"oneimg/backend/utils/result"
+	"oneimg/backend/utils/settings"
 	"strconv"
 	"strings"
 	"time"
@@ -106,18 +107,27 @@ func GetRandomImages(c *gin.Context) {
 		}
 	}
 
+	setting, err := settings.GetSettings()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, result.Error(500, "获取系统配置失败"))
+		return
+	}
+
 	if model == "image" {
 		if len(images) == 0 {
 			c.JSON(http.StatusNotFound, result.Error(404, "暂无图片"))
 			return
 		}
 
+		publicURL := applyPublicImageURL(setting, images[0].Storage, images[0].Url)
+		if strings.HasPrefix(publicURL, "http://") || strings.HasPrefix(publicURL, "https://") {
+			c.Redirect(http.StatusFound, publicURL)
+			return
+		}
+
 		originalPath := c.Request.URL.Path
 		originalRawPath := c.Request.URL.RawPath
-		imageURL := images[0].Url
-		if !strings.HasPrefix(imageURL, "/") {
-			imageURL = "/" + imageURL
-		}
+		imageURL := ensureLeadingSlash(images[0].Url)
 
 		c.Request.URL.Path = imageURL
 		c.Request.URL.RawPath = imageURL
@@ -130,7 +140,7 @@ func GetRandomImages(c *gin.Context) {
 		return
 	}
 	for _, img := range images {
-		fullUrl := getFullImageUrl(c, img.Url)
+		fullUrl := buildImageResponseURL(c, setting, img.Storage, img.Url)
 		respData = append(respData, RandomImageResponse{
 			Image: img.FileName,
 			Url:   fullUrl,
@@ -138,28 +148,4 @@ func GetRandomImages(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, result.Success("ok", respData))
-}
-
-func getFullImageUrl(c *gin.Context, path string) string {
-	var scheme string
-	if proto := c.GetHeader("X-Forwarded-Proto"); proto != "" {
-		scheme = proto
-	} else if c.Request.TLS != nil {
-		scheme = "https"
-	} else {
-		scheme = "http"
-	}
-	var host string
-	if forwardedHost := c.GetHeader("X-Forwarded-Host"); forwardedHost != "" {
-		host = forwardedHost
-	} else {
-		host = c.Request.Host
-	}
-	baseUrl := scheme + "://" + host
-	baseUrl = strings.TrimSuffix(baseUrl, "/")
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	fullUrl := baseUrl + path
-	return fullUrl
 }

--- a/backend/controllers/ImageDetail.go
+++ b/backend/controllers/ImageDetail.go
@@ -6,6 +6,7 @@ import (
 
 	"oneimg/backend/database"
 	"oneimg/backend/models"
+	"oneimg/backend/utils/settings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -42,6 +43,16 @@ func GetImageDetail(c *gin.Context) {
 		})
 		return
 	}
+
+	setting, err := settings.GetSettings()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code": 500,
+			"msg":  "获取系统配置失败",
+		})
+		return
+	}
+	rewriteImageURLs(setting, &image)
 
 	c.JSON(http.StatusOK, gin.H{
 		"code": 200,

--- a/backend/controllers/ImageList.go
+++ b/backend/controllers/ImageList.go
@@ -235,8 +235,8 @@ func GetImageList(c *gin.Context) {
 		return
 	}
 	for i := range images {
-		images[i].Url = applyPublicImageURL(setting, images[i].Storage, images[i].Url)
-		images[i].Thumbnail = applyPublicImageURL(setting, images[i].Storage, images[i].Thumbnail)
+		images[i].Url = applyPublicImageURL(setting, images[i].Storage, images[i].BucketId, images[i].Url)
+		images[i].Thumbnail = applyPublicImageURL(setting, images[i].Storage, images[i].BucketId, images[i].Thumbnail)
 	}
 
 	// 返回结果

--- a/backend/controllers/ImageList.go
+++ b/backend/controllers/ImageList.go
@@ -9,6 +9,7 @@ import (
 	"oneimg/backend/database"
 	"oneimg/backend/models"
 	"oneimg/backend/utils/result"
+	"oneimg/backend/utils/settings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -226,6 +227,16 @@ func GetImageList(c *gin.Context) {
 			}
 			images[i].Tags = tagList
 		}
+	}
+
+	setting, err := settings.GetSettings()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, result.Error(500, "获取系统配置失败："+err.Error()))
+		return
+	}
+	for i := range images {
+		images[i].Url = applyPublicImageURL(setting, images[i].Storage, images[i].Url)
+		images[i].Thumbnail = applyPublicImageURL(setting, images[i].Storage, images[i].Thumbnail)
 	}
 
 	// 返回结果

--- a/backend/controllers/ImageURL.go
+++ b/backend/controllers/ImageURL.go
@@ -9,21 +9,21 @@ import (
 	"oneimg/backend/utils/publicurl"
 )
 
-func buildImageResponseURL(c *gin.Context, setting models.Settings, storage string, path string) string {
-	publicPath := publicurl.BuildForStorage(setting, storage, path)
+func buildImageResponseURL(c *gin.Context, setting models.Settings, storage string, bucketID int, path string) string {
+	publicPath := publicurl.BuildForStorage(setting, storage, bucketID, path)
 	if publicPath == "" || strings.HasPrefix(publicPath, "http://") || strings.HasPrefix(publicPath, "https://") {
 		return publicPath
 	}
 	return getRequestBaseURL(c) + ensureLeadingSlash(publicPath)
 }
 
-func applyPublicImageURL(setting models.Settings, storage string, path string) string {
-	return publicurl.BuildForStorage(setting, storage, path)
+func applyPublicImageURL(setting models.Settings, storage string, bucketID int, path string) string {
+	return publicurl.BuildForStorage(setting, storage, bucketID, path)
 }
 
 func rewriteImageURLs(setting models.Settings, image *models.Image) {
-	image.Url = applyPublicImageURL(setting, image.Storage, image.Url)
-	image.Thumbnail = applyPublicImageURL(setting, image.Storage, image.Thumbnail)
+	image.Url = applyPublicImageURL(setting, image.Storage, image.BucketId, image.Url)
+	image.Thumbnail = applyPublicImageURL(setting, image.Storage, image.BucketId, image.Thumbnail)
 }
 
 func getRequestBaseURL(c *gin.Context) string {

--- a/backend/controllers/ImageURL.go
+++ b/backend/controllers/ImageURL.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"oneimg/backend/models"
+	"oneimg/backend/utils/publicurl"
+)
+
+func buildImageResponseURL(c *gin.Context, setting models.Settings, storage string, path string) string {
+	publicPath := publicurl.BuildForStorage(setting, storage, path)
+	if publicPath == "" || strings.HasPrefix(publicPath, "http://") || strings.HasPrefix(publicPath, "https://") {
+		return publicPath
+	}
+	return getRequestBaseURL(c) + ensureLeadingSlash(publicPath)
+}
+
+func applyPublicImageURL(setting models.Settings, storage string, path string) string {
+	return publicurl.BuildForStorage(setting, storage, path)
+}
+
+func rewriteImageURLs(setting models.Settings, image *models.Image) {
+	image.Url = applyPublicImageURL(setting, image.Storage, image.Url)
+	image.Thumbnail = applyPublicImageURL(setting, image.Storage, image.Thumbnail)
+}
+
+func getRequestBaseURL(c *gin.Context) string {
+	scheme := "http"
+	if proto := firstForwardedValue(c.GetHeader("X-Forwarded-Proto")); proto != "" {
+		scheme = proto
+	} else if c.Request.TLS != nil {
+		scheme = "https"
+	}
+
+	host := c.Request.Host
+	if forwardedHost := firstForwardedValue(c.GetHeader("X-Forwarded-Host")); forwardedHost != "" {
+		host = forwardedHost
+	}
+
+	return strings.TrimSuffix(scheme+"://"+host, "/")
+}
+
+func ensureLeadingSlash(path string) string {
+	if path == "" || strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
+}
+
+func firstForwardedValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.Split(value, ",")[0])
+}

--- a/backend/controllers/ImageUpload.go
+++ b/backend/controllers/ImageUpload.go
@@ -181,23 +181,18 @@ func UploadImages(c *gin.Context) {
 			db.DB.Create(&imageTagRelations)
 		}
 
-		uploadResults = append(uploadResults, *fileResult)
+		responseResult := *fileResult
+		responseResult.URL = applyPublicImageURL(setting, buckets.Type, fileResult.URL)
+		responseResult.ThumbnailURL = applyPublicImageURL(setting, buckets.Type, fileResult.ThumbnailURL)
+		uploadResults = append(uploadResults, responseResult)
 
 		if setting.TGNotice {
-			requestHost := c.Request.Host
-			if c.GetHeader("X-Forwarded-Host") != "" {
-				requestHost = c.GetHeader("X-Forwarded-Host")
-			}
-			scheme := "http://"
-			if c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https" {
-				scheme = "https://"
-			}
 			placeholderData := telegram.PlaceholderData{
 				Username:    c.GetString("username"),
 				Date:        time.Now().Format("2006-01-02 15:04:05"),
 				Filename:    fileResult.FileName,
 				StorageType: buckets.Type,
-				URL:         scheme + requestHost + fileResult.URL,
+				URL:         buildImageResponseURL(c, setting, buckets.Type, fileResult.URL),
 			}
 
 			err := telegram.SendSimpleMsg(
@@ -692,25 +687,23 @@ func UploadImagesByURL(c *gin.Context) {
 
 	// TG通知
 	if setting.TGNotice {
-		requestHost := c.Request.Host
-		if c.GetHeader("X-Forwarded-Host") != "" {
-			requestHost = c.GetHeader("X-Forwarded-Host")
-		}
-		scheme := "http://"
-		if c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https" {
-			scheme = "https://"
-		}
 		placeholderData := telegram.PlaceholderData{
 			Username:    c.GetString("username"),
 			Date:        time.Now().Format("2006-01-02 15:04:05"),
 			Filename:    fileResult.FileName,
 			StorageType: buckets.Type,
-			URL:         scheme + requestHost + fileResult.URL,
+			URL:         buildImageResponseURL(c, setting, buckets.Type, fileResult.URL),
 		}
 		if err := telegram.SendSimpleMsg(setting.TGBotToken, setting.TGReceivers, setting.TGNoticeText, placeholderData); err != nil {
 			log.Println(err)
 		}
 	}
 
-	uc.Success("URL 图片上传成功", nil)
+	responseResult := *fileResult
+	responseResult.URL = applyPublicImageURL(setting, buckets.Type, fileResult.URL)
+	responseResult.ThumbnailURL = applyPublicImageURL(setting, buckets.Type, fileResult.ThumbnailURL)
+
+	uc.Success("URL 图片上传成功", map[string]any{
+		"file": responseResult,
+	})
 }

--- a/backend/controllers/ImageUpload.go
+++ b/backend/controllers/ImageUpload.go
@@ -182,8 +182,8 @@ func UploadImages(c *gin.Context) {
 		}
 
 		responseResult := *fileResult
-		responseResult.URL = applyPublicImageURL(setting, buckets.Type, fileResult.URL)
-		responseResult.ThumbnailURL = applyPublicImageURL(setting, buckets.Type, fileResult.ThumbnailURL)
+		responseResult.URL = applyPublicImageURL(setting, buckets.Type, bucketID, fileResult.URL)
+		responseResult.ThumbnailURL = applyPublicImageURL(setting, buckets.Type, bucketID, fileResult.ThumbnailURL)
 		uploadResults = append(uploadResults, responseResult)
 
 		if setting.TGNotice {
@@ -192,7 +192,7 @@ func UploadImages(c *gin.Context) {
 				Date:        time.Now().Format("2006-01-02 15:04:05"),
 				Filename:    fileResult.FileName,
 				StorageType: buckets.Type,
-				URL:         buildImageResponseURL(c, setting, buckets.Type, fileResult.URL),
+				URL:         buildImageResponseURL(c, setting, buckets.Type, bucketID, fileResult.URL),
 			}
 
 			err := telegram.SendSimpleMsg(
@@ -692,7 +692,7 @@ func UploadImagesByURL(c *gin.Context) {
 			Date:        time.Now().Format("2006-01-02 15:04:05"),
 			Filename:    fileResult.FileName,
 			StorageType: buckets.Type,
-			URL:         buildImageResponseURL(c, setting, buckets.Type, fileResult.URL),
+			URL:         buildImageResponseURL(c, setting, buckets.Type, bucketID, fileResult.URL),
 		}
 		if err := telegram.SendSimpleMsg(setting.TGBotToken, setting.TGReceivers, setting.TGNoticeText, placeholderData); err != nil {
 			log.Println(err)
@@ -700,8 +700,8 @@ func UploadImagesByURL(c *gin.Context) {
 	}
 
 	responseResult := *fileResult
-	responseResult.URL = applyPublicImageURL(setting, buckets.Type, fileResult.URL)
-	responseResult.ThumbnailURL = applyPublicImageURL(setting, buckets.Type, fileResult.ThumbnailURL)
+	responseResult.URL = applyPublicImageURL(setting, buckets.Type, bucketID, fileResult.URL)
+	responseResult.ThumbnailURL = applyPublicImageURL(setting, buckets.Type, bucketID, fileResult.ThumbnailURL)
 
 	uc.Success("URL 图片上传成功", map[string]any{
 		"file": responseResult,

--- a/backend/controllers/Settings.go
+++ b/backend/controllers/Settings.go
@@ -15,6 +15,7 @@ import (
 
 	"oneimg/backend/database"
 	"oneimg/backend/models"
+	"oneimg/backend/utils/publicurl"
 	"oneimg/backend/utils/result"
 	"oneimg/backend/utils/secureconfig"
 	"oneimg/backend/utils/settings"
@@ -193,6 +194,12 @@ func buildSettingsUpdate(key string, value any, fieldName string, fieldType refl
 		return "api_token_hash", normalizedValue, nil
 	case "tg_bot_token":
 		return "tg_bot_token", normalizedValue, nil
+	case "public_image_domain":
+		domain, err := publicurl.NormalizeDomain(fmt.Sprintf("%v", value))
+		if err != nil {
+			return "", nil, err
+		}
+		return "public_image_domain", domain, nil
 	default:
 		convertedValue, convertErr := convertValueToTargetType(key, value, fieldType)
 		if convertErr != nil {
@@ -337,7 +344,37 @@ func convertValueToTargetType(key string, value any, targetType reflect.Type) (a
 }
 
 func validateSettingData(key string, value any) error {
+	if settingDisabledByPublicDomain(key) {
+		setting, err := settings.GetSettings()
+		if err != nil {
+			return fmt.Errorf("获取系统配置失败")
+		}
+		if publicurl.HasDomain(setting) {
+			return fmt.Errorf("已配置图片直链域名，该设置不会生效，请先清空图片直链域名")
+		}
+	}
+
 	switch key {
+	case "public_image_domain":
+		domain, err := publicurl.NormalizeDomain(fmt.Sprintf("%v", value))
+		if err != nil {
+			return err
+		}
+		if domain == "" {
+			return nil
+		}
+		setting, err := settings.GetSettings()
+		if err != nil {
+			return fmt.Errorf("获取系统配置失败")
+		}
+		bucketType, err := getBucketTypeByID(setting.DefaultStorage)
+		if err != nil {
+			return err
+		}
+		if !publicurl.SupportsStorage(bucketType) {
+			return fmt.Errorf("当前默认存储不支持图片直链域名，请先切换到 S3 或 R2 存储")
+		}
+
 	case "watermark_text":
 		// 1. 水印文字长度校验（兼容字符串类型）
 		text, ok := value.(string)
@@ -437,28 +474,67 @@ func validateSettingData(key string, value any) error {
 		}
 	case "default_storage":
 		// 检查存储配置是否存在
-		db := database.GetDB().DB
-
-		var id int
-		switch v := value.(type) {
-		case int:
-			id = v
-		case string:
-			num64, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("%s", "解析失败: "+err.Error())
-			}
-			id = int(num64)
+		id, err := settingValueToInt(value)
+		if err != nil {
+			return fmt.Errorf("%s", "解析失败: "+err.Error())
 		}
 
-		Buckets := models.Buckets{
-			Id: id,
+		bucketType, err := getBucketTypeByID(id)
+		if err != nil {
+			return err
 		}
-
-		if err := db.First(&Buckets).Error; err != nil {
-			return fmt.Errorf("存储桶不存在")
+		setting, err := settings.GetSettings()
+		if err != nil {
+			return fmt.Errorf("获取系统配置失败")
+		}
+		if publicurl.HasDomain(setting) && !publicurl.SupportsStorage(bucketType) {
+			return fmt.Errorf("图片直链域名仅支持 S3/R2 存储，请先清空该配置")
 		}
 	}
 
 	return nil
+}
+
+func settingDisabledByPublicDomain(key string) bool {
+	switch key {
+	case "watermark_enable",
+		"watermark_text",
+		"watermark_size",
+		"watermark_color",
+		"watermark_opac",
+		"watermark_pos",
+		"referer_white_enable",
+		"referer_white_list":
+		return true
+	default:
+		return false
+	}
+}
+
+func getBucketTypeByID(id int) (string, error) {
+	db := database.GetDB().DB
+	var bucket models.Buckets
+	if err := db.First(&bucket, id).Error; err != nil {
+		return "", fmt.Errorf("存储桶不存在")
+	}
+	return bucket.Type, nil
+}
+
+func settingValueToInt(value any) (int, error) {
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case string:
+		num64, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return int(num64), nil
+	default:
+		return 0, fmt.Errorf("类型错误：%T", value)
+	}
 }

--- a/backend/controllers/Settings.go
+++ b/backend/controllers/Settings.go
@@ -19,6 +19,8 @@ import (
 	"oneimg/backend/utils/result"
 	"oneimg/backend/utils/secureconfig"
 	"oneimg/backend/utils/settings"
+
+	"gorm.io/gorm"
 )
 
 // 定义请求参数
@@ -132,6 +134,12 @@ func UpdateSettings(c *gin.Context) {
 		return
 	}
 
+	if err := ensureSettingsColumn(db, updateColumn); err != nil {
+		c.JSON(http.StatusInternalServerError, result.Error(500, "数据库字段兼容处理失败"))
+		log.Println(err)
+		return
+	}
+
 	if err := db.Model(&settingModel).Update(updateColumn, updateValue).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, result.Error(500, "更新失败"))
 		log.Println(err)
@@ -220,6 +228,33 @@ func getSettingsColumnName(fieldName string) string {
 		}
 	}
 	return fieldName
+}
+
+func ensureSettingsColumn(db *gorm.DB, columnName string) error {
+	fieldName, err := getSettingsFieldNameByColumn(columnName)
+	if err != nil {
+		return err
+	}
+	if db.Migrator().HasColumn(&models.Settings{}, columnName) {
+		return nil
+	}
+
+	log.Printf("[数据库兼容] settings.%s 字段不存在，尝试创建", columnName)
+	if err := db.Migrator().AddColumn(&models.Settings{}, fieldName); err != nil {
+		return fmt.Errorf("创建 settings.%s 字段失败: %w", columnName, err)
+	}
+	return nil
+}
+
+func getSettingsFieldNameByColumn(columnName string) (string, error) {
+	settingsType := reflect.TypeOf(models.Settings{})
+	for i := 0; i < settingsType.NumField(); i++ {
+		field := settingsType.Field(i)
+		if getSettingsColumnName(field.Name) == columnName || field.Name == columnName {
+			return field.Name, nil
+		}
+	}
+	return "", fmt.Errorf("设置字段 %s 不存在", columnName)
 }
 
 func updateSettingsField(settings *models.Settings, key string, value any) error {

--- a/backend/controllers/Stats.go
+++ b/backend/controllers/Stats.go
@@ -6,6 +6,7 @@ import (
 
 	"oneimg/backend/database"
 	"oneimg/backend/models"
+	"oneimg/backend/utils/settings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -82,6 +83,18 @@ func GetDashboardStats(c *gin.Context) {
 
 	// 获取最近上传的图片
 	db.Order("created_at DESC").Limit(10).Find(&stats.RecentImages)
+	setting, err := settings.GetSettings()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, StatsResponse{
+			Code:    500,
+			Message: "获取系统配置失败",
+			Success: false,
+		})
+		return
+	}
+	for i := range stats.RecentImages {
+		rewriteImageURLs(setting, &stats.RecentImages[i])
+	}
 
 	// 获取最近7天的上传趋势
 	stats.UploadTrend = getUploadTrend(db, 7)

--- a/backend/models/Settings.go
+++ b/backend/models/Settings.go
@@ -31,6 +31,9 @@ type Settings struct {
 	DefaultPath  string `gorm:"column:default_path;default:'/uploads/{year}/{moon}'" json:"default_path"` // 默认上传路径，魔法变量 {year} 年 {month} 月 {day} 日 {hour} 小时 {minute} 分钟 {random} 随机 {uuid} UUID {role} 角色（1 为管理员, 2 为游客）
 	FileName     string `gorm:"column:file_name;default:'{random}'" json:"file_name"`                     // 上传文件名称，魔法变量 {random} 随机数 {year} 年 {month} 月 {day} 日 {hour} 小时 {minute} 分钟 {second} 秒
 
+	// 图片直链设置
+	PublicImageDomain string `gorm:"column:public_image_domain;default:''" json:"public_image_domain"` // 图片直链域名（用于非本地存储直接访问）
+
 	// 水印设置
 	WatermarkEnable bool    `gorm:"column:watermark_enable;default:false" json:"watermark_enable"`    // 是否启用水印（默认不启用）
 	WatermarkText   string  `gorm:"column:watermark_text;default:'初春图床'" json:"watermark_text"`       // 水印文字（默认为初春图床）

--- a/backend/utils/publicurl/publicurl.go
+++ b/backend/utils/publicurl/publicurl.go
@@ -1,0 +1,74 @@
+package publicurl
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"oneimg/backend/models"
+)
+
+func NormalizeDomain(value string) (string, error) {
+	domain := strings.TrimSpace(value)
+	if domain == "" {
+		return "", nil
+	}
+
+	if !strings.Contains(domain, "://") {
+		domain = "https://" + domain
+	}
+
+	parsed, err := url.Parse(domain)
+	if err != nil {
+		return "", fmt.Errorf("图片直链域名格式错误")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("图片直链域名仅支持 http 或 https")
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("图片直链域名缺少域名")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("图片直链域名不能包含查询参数或锚点")
+	}
+
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func HasDomain(setting models.Settings) bool {
+	domain, err := NormalizeDomain(setting.PublicImageDomain)
+	return err == nil && domain != ""
+}
+
+func Build(setting models.Settings, imagePath string) string {
+	path := strings.TrimSpace(imagePath)
+	if path == "" || isAbsoluteURL(path) {
+		return path
+	}
+
+	domain, err := NormalizeDomain(setting.PublicImageDomain)
+	if err != nil || domain == "" {
+		return path
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return strings.TrimRight(domain, "/") + path
+}
+
+func BuildForStorage(setting models.Settings, storage string, imagePath string) string {
+	if !SupportsStorage(storage) {
+		return imagePath
+	}
+	return Build(setting, imagePath)
+}
+
+func SupportsStorage(storage string) bool {
+	return storage == "r2" || storage == "s3"
+}
+
+func isAbsoluteURL(value string) bool {
+	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
+}

--- a/backend/utils/publicurl/publicurl.go
+++ b/backend/utils/publicurl/publicurl.go
@@ -58,8 +58,8 @@ func Build(setting models.Settings, imagePath string) string {
 	return strings.TrimRight(domain, "/") + path
 }
 
-func BuildForStorage(setting models.Settings, storage string, imagePath string) string {
-	if !SupportsStorage(storage) {
+func BuildForStorage(setting models.Settings, storage string, bucketID int, imagePath string) string {
+	if !SupportsStorage(storage) || bucketID != setting.DefaultStorage {
 		return imagePath
 	}
 	return Build(setting, imagePath)

--- a/backend/utils/publicurl/publicurl_test.go
+++ b/backend/utils/publicurl/publicurl_test.go
@@ -1,0 +1,49 @@
+package publicurl
+
+import (
+	"testing"
+
+	"oneimg/backend/models"
+)
+
+func TestBuildForStorageOnlyRewritesDefaultSupportedBucket(t *testing.T) {
+	setting := models.Settings{
+		DefaultStorage:    2,
+		PublicImageDomain: "img.example.com",
+	}
+
+	tests := []struct {
+		name    string
+		storage string
+		bucket  int
+		want    string
+	}{
+		{
+			name:    "default supported bucket",
+			storage: "s3",
+			bucket:  2,
+			want:    "https://img.example.com/uploads/a.webp",
+		},
+		{
+			name:    "same storage different bucket",
+			storage: "s3",
+			bucket:  8,
+			want:    "/uploads/a.webp",
+		},
+		{
+			name:    "unsupported storage default bucket",
+			storage: "default",
+			bucket:  2,
+			want:    "/uploads/a.webp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildForStorage(setting, tt.storage, tt.bucket, "/uploads/a.webp")
+			if got != tt.want {
+				t.Fatalf("BuildForStorage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/utils/secureconfig/secureconfig.go
+++ b/backend/utils/secureconfig/secureconfig.go
@@ -93,6 +93,7 @@ func SanitizeSettingsForResponse(setting models.Settings) map[string]any {
 		"default_storage":         setting.DefaultStorage,
 		"max_file_size":           setting.MaxFileSize,
 		"allowed_types":           setting.AllowedTypes,
+		"public_image_domain":     setting.PublicImageDomain,
 		"watermark_enable":        setting.WatermarkEnable,
 		"watermark_text":          setting.WatermarkText,
 		"watermark_pos":           setting.WatermarkPos,

--- a/backend/utils/uploads/uploads.go
+++ b/backend/utils/uploads/uploads.go
@@ -21,6 +21,7 @@ import (
 	"oneimg/backend/utils/buckets"
 	"oneimg/backend/utils/ftp"
 	"oneimg/backend/utils/images"
+	"oneimg/backend/utils/publicurl"
 	"oneimg/backend/utils/s3"
 	"oneimg/backend/utils/telegram"
 	"oneimg/backend/utils/webdav"
@@ -52,7 +53,7 @@ func (u *R2Uploader) Upload(c *gin.Context, setting *models.Settings, bucket *mo
 	userRole := c.GetInt("user_role")
 
 	// 处理图片
-	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, *setting, userRole)
+	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, getProcessingSettings(setting, bucket), userRole)
 	if err != nil {
 		return nil, fmt.Errorf("图片处理失败: %v", err)
 	}
@@ -110,18 +111,18 @@ func (u *R2Uploader) Upload(c *gin.Context, setting *models.Settings, bucket *mo
 	url := "/" + PathJoin(subDir, uniqueFileName)
 
 	return &interfaces.ImageUploadResult{
-		Success:      true,
-		Message:      "上传成功",
-		FileName:     uniqueFileName,
-		FileSize:     int64(len(processedImage.CompressedBytes)),
+		Success:       true,
+		Message:       "上传成功",
+		FileName:      uniqueFileName,
+		FileSize:      int64(len(processedImage.CompressedBytes)),
 		ThumbnailSize: int64(len(processedImage.ThumbnailBytes)),
-		MimeType:     contentType,
-		URL:          url,
-		ThumbnailURL: thumbnailURL,
-		Storage:      bucket.Type,
-		CreatedAt:    time.Now().Format("2006-01-02 15:04:05"),
-		Width:        processedImage.Width,
-		Height:       processedImage.Height,
+		MimeType:      contentType,
+		URL:           url,
+		ThumbnailURL:  thumbnailURL,
+		Storage:       bucket.Type,
+		CreatedAt:     time.Now().Format("2006-01-02 15:04:05"),
+		Width:         processedImage.Width,
+		Height:        processedImage.Height,
 	}, nil
 }
 
@@ -143,7 +144,7 @@ func (u *S3Uploader) Upload(c *gin.Context, setting *models.Settings, bucket *mo
 	userRole := c.GetInt("user_role")
 
 	// 处理图片
-	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, *setting, userRole)
+	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, getProcessingSettings(setting, bucket), userRole)
 	if err != nil {
 		return nil, fmt.Errorf("图片处理失败: %v", err)
 	}
@@ -201,18 +202,18 @@ func (u *S3Uploader) Upload(c *gin.Context, setting *models.Settings, bucket *mo
 	url := "/" + PathJoin(subDir, uniqueFileName)
 
 	return &interfaces.ImageUploadResult{
-		Success:      true,
-		Message:      "上传成功",
-		FileName:     uniqueFileName,
-		FileSize:     int64(len(processedImage.CompressedBytes)),
+		Success:       true,
+		Message:       "上传成功",
+		FileName:      uniqueFileName,
+		FileSize:      int64(len(processedImage.CompressedBytes)),
 		ThumbnailSize: int64(len(processedImage.ThumbnailBytes)),
-		MimeType:     contentType,
-		URL:          url,
-		ThumbnailURL: thumbnailURL,
-		Storage:      bucket.Type,
-		CreatedAt:    time.Now().Format("2006-01-02 15:04:05"),
-		Width:        processedImage.Width,
-		Height:       processedImage.Height,
+		MimeType:      contentType,
+		URL:           url,
+		ThumbnailURL:  thumbnailURL,
+		Storage:       bucket.Type,
+		CreatedAt:     time.Now().Format("2006-01-02 15:04:05"),
+		Width:         processedImage.Width,
+		Height:        processedImage.Height,
 	}, nil
 }
 
@@ -234,7 +235,7 @@ func (u *WebDAVUploader) Upload(c *gin.Context, setting *models.Settings, bucket
 	userRole := c.GetInt("user_role")
 
 	// 处理图片
-	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, *setting, userRole)
+	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, getProcessingSettings(setting, bucket), userRole)
 	if err != nil {
 		return nil, fmt.Errorf("图片处理失败: %v", err)
 	}
@@ -285,18 +286,18 @@ func (u *WebDAVUploader) Upload(c *gin.Context, setting *models.Settings, bucket
 	url := PathJoin(subDir, uniqueFileName)
 
 	return &interfaces.ImageUploadResult{
-		Success:      true,
-		Message:      "上传成功",
-		FileName:     uniqueFileName,
-		FileSize:     int64(len(processedImage.CompressedBytes)),
+		Success:       true,
+		Message:       "上传成功",
+		FileName:      uniqueFileName,
+		FileSize:      int64(len(processedImage.CompressedBytes)),
 		ThumbnailSize: int64(len(processedImage.ThumbnailBytes)),
-		MimeType:     processedImage.MimeType,
-		URL:          url,
-		ThumbnailURL: thumbnailURL,
-		Storage:      bucket.Type,
-		Width:        processedImage.Width,
-		Height:       processedImage.Height,
-		CreatedAt:    time.Now().Format("2006-01-02 15:04:05"),
+		MimeType:      processedImage.MimeType,
+		URL:           url,
+		ThumbnailURL:  thumbnailURL,
+		Storage:       bucket.Type,
+		Width:         processedImage.Width,
+		Height:        processedImage.Height,
+		CreatedAt:     time.Now().Format("2006-01-02 15:04:05"),
 	}, nil
 }
 
@@ -318,7 +319,7 @@ func (u *FTPUploader) Upload(c *gin.Context, setting *models.Settings, bucket *m
 	userRole := c.GetInt("user_role")
 
 	// 处理图片（压缩、生成缩略图等）
-	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, *setting, userRole)
+	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, getProcessingSettings(setting, bucket), userRole)
 	if err != nil {
 		return nil, fmt.Errorf("图片处理失败: %v", err)
 	}
@@ -371,18 +372,18 @@ func (u *FTPUploader) Upload(c *gin.Context, setting *models.Settings, bucket *m
 	url := "/" + PathJoin(subDir, uniqueFileName)
 
 	return &interfaces.ImageUploadResult{
-		Success:      true,
-		Message:      "上传成功",
-		FileName:     uniqueFileName,
-		FileSize:     int64(len(processedImage.CompressedBytes)),
+		Success:       true,
+		Message:       "上传成功",
+		FileName:      uniqueFileName,
+		FileSize:      int64(len(processedImage.CompressedBytes)),
 		ThumbnailSize: int64(len(processedImage.ThumbnailBytes)),
-		MimeType:     processedImage.MimeType,
-		URL:          url,
-		ThumbnailURL: thumbnailURL,
-		Storage:      bucket.Type,
-		Width:        processedImage.Width,
-		Height:       processedImage.Height,
-		CreatedAt:    time.Now().Format("2006-01-02 15:04:05"),
+		MimeType:      processedImage.MimeType,
+		URL:           url,
+		ThumbnailURL:  thumbnailURL,
+		Storage:       bucket.Type,
+		Width:         processedImage.Width,
+		Height:        processedImage.Height,
+		CreatedAt:     time.Now().Format("2006-01-02 15:04:05"),
 	}, nil
 }
 
@@ -404,7 +405,7 @@ func (u *DefaultUploader) Upload(c *gin.Context, setting *models.Settings, bucke
 	userRole := c.GetInt("user_role")
 
 	// 处理图片
-	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, *setting, userRole)
+	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, getProcessingSettings(setting, bucket), userRole)
 	if err != nil {
 		return nil, fmt.Errorf("图片处理失败: %v", err)
 	}
@@ -452,18 +453,18 @@ func (u *DefaultUploader) Upload(c *gin.Context, setting *models.Settings, bucke
 	fileURL := "/" + PathJoin(subDir, uniqueFileName)
 
 	return &interfaces.ImageUploadResult{
-		Success:      true,
-		Message:      "上传成功",
-		URL:          fileURL,
-		ThumbnailURL: thumbnailURL,
-		Storage:      bucket.Type,
-		FileName:     uniqueFileName,
-		FileSize:     int64(len(processedImage.CompressedBytes)),
+		Success:       true,
+		Message:       "上传成功",
+		URL:           fileURL,
+		ThumbnailURL:  thumbnailURL,
+		Storage:       bucket.Type,
+		FileName:      uniqueFileName,
+		FileSize:      int64(len(processedImage.CompressedBytes)),
 		ThumbnailSize: int64(len(processedImage.ThumbnailBytes)),
-		MimeType:     processedImage.MimeType,
-		Width:        processedImage.Width,
-		Height:       processedImage.Height,
-		CreatedAt:    time.Now().Format("2006-01-02 15:04:05"),
+		MimeType:      processedImage.MimeType,
+		Width:         processedImage.Width,
+		Height:        processedImage.Height,
+		CreatedAt:     time.Now().Format("2006-01-02 15:04:05"),
 	}, nil
 }
 
@@ -485,7 +486,7 @@ func (u *TelegramUploader) Upload(c *gin.Context, setting *models.Settings, buck
 	userRole := c.GetInt("user_role")
 
 	// 处理图片
-	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, *setting, userRole)
+	processedImage, err := images.ImageSvc.ProcessImage(file, fileHeader, getProcessingSettings(setting, bucket), userRole)
 	if err != nil {
 		return nil, fmt.Errorf("图片处理失败: %v", err)
 	}
@@ -564,18 +565,18 @@ func (u *TelegramUploader) Upload(c *gin.Context, setting *models.Settings, buck
 	}
 
 	return &interfaces.ImageUploadResult{
-		Success:      true,
-		Message:      "Telegram上传成功",
-		FileName:     processedImage.UniqueFileName,
-		FileSize:     int64(len(processedImage.CompressedBytes)),
+		Success:       true,
+		Message:       "Telegram上传成功",
+		FileName:      processedImage.UniqueFileName,
+		FileSize:      int64(len(processedImage.CompressedBytes)),
 		ThumbnailSize: int64(len(processedImage.ThumbnailBytes)),
-		MimeType:     processedImage.MimeType,
-		URL:          url,
-		ThumbnailURL: thumbnailURL,
-		Storage:      bucket.Type, // 存储类型标识
-		CreatedAt:    time.Now().Format("2006-01-02 15:04:05"),
-		Width:        processedImage.Width,
-		Height:       processedImage.Height,
+		MimeType:      processedImage.MimeType,
+		URL:           url,
+		ThumbnailURL:  thumbnailURL,
+		Storage:       bucket.Type, // 存储类型标识
+		CreatedAt:     time.Now().Format("2006-01-02 15:04:05"),
+		Width:         processedImage.Width,
+		Height:        processedImage.Height,
 	}, nil
 }
 
@@ -597,6 +598,14 @@ func saveFile(filePath string, data []byte) error {
 
 	_, err = file.Write(data)
 	return err
+}
+
+func getProcessingSettings(setting *models.Settings, bucket *models.Buckets) models.Settings {
+	processingSettings := *setting
+	if publicurl.HasDomain(*setting) && publicurl.SupportsStorage(bucket.Type) {
+		processingSettings.WatermarkEnable = false
+	}
+	return processingSettings
 }
 
 // 辅助函数

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -52,6 +52,29 @@
                                 </div>
                             </div>
 
+                            <!-- 图片直链域名 -->
+                            <div class="setting-group">
+                                <label class="field-label" for="public_image_domain">
+                                    图片直链域名
+                                </label>
+                                <input
+                                    id="public_image_domain"
+                                    v-model="systemSettings.public_image_domain"
+                                    type="text"
+                                    class="input-modern"
+                                    :class="{ 'cursor-not-allowed opacity-60': publicImageDomainUnavailable }"
+                                    :disabled="publicImageDomainUnavailable"
+                                    placeholder="例如 https://img.example.com"
+                                    @blur="handleFieldBlur('public_image_domain', systemSettings.public_image_domain)"
+                                />
+                                <div
+                                    class="field-hint"
+                                    :class="{ 'text-amber-600 dark:text-amber-300': publicImageDomainUnavailable || hasPublicImageDomain }"
+                                >
+                                    {{ publicImageDomainHint }}
+                                </div>
+                            </div>
+
                             <!-- 默认存储路径 -->
                             <div class="setting-group">
                                 <label class="field-label" for="default_path">
@@ -154,9 +177,14 @@
                                     v-model="systemSettings.watermark_text"
                                     type="text" 
                                     class="input-modern"
+                                    :class="{ 'cursor-not-allowed opacity-60': hasPublicImageDomain }"
+                                    :disabled="hasPublicImageDomain"
                                     placeholder="图片水印文本"
                                     @blur="handleFieldBlur('watermark_text', systemSettings.watermark_text)"
                                 />
+                                <div v-if="hasPublicImageDomain" class="field-hint text-amber-600 dark:text-amber-300">
+                                    已配置图片直链域名，图片水印文本不会生效，请先清空图片直链域名再修改。
+                                </div>
                             </div>
 
                             <!-- 图片水印大小：失去焦点保存 -->
@@ -169,6 +197,8 @@
                                     v-model="systemSettings.watermark_size"
                                     type="text" 
                                     class="input-modern"
+                                    :class="{ 'cursor-not-allowed opacity-60': hasPublicImageDomain }"
+                                    :disabled="hasPublicImageDomain"
                                     placeholder="图片水印大小"
                                     @blur="handleFieldBlur('watermark_size', systemSettings.watermark_size)"
                                 />
@@ -184,6 +214,8 @@
                                     v-model="systemSettings.watermark_color"
                                     type="text" 
                                     class="input-modern"
+                                    :class="{ 'cursor-not-allowed opacity-60': hasPublicImageDomain }"
+                                    :disabled="hasPublicImageDomain"
                                     placeholder="图片水印字体颜色"
                                     @blur="handleFieldBlur('watermark_color', systemSettings.watermark_color)"
                                 />
@@ -202,6 +234,8 @@
                                     v-model="systemSettings.watermark_opac"
                                     type="text" 
                                     class="input-modern"
+                                    :class="{ 'cursor-not-allowed opacity-60': hasPublicImageDomain }"
+                                    :disabled="hasPublicImageDomain"
                                     placeholder="图片水印透明度"
                                     @blur="handleFieldBlur('watermark_opac', systemSettings.watermark_opac)"
                                 />
@@ -219,6 +253,8 @@
                                     id="watermark_pos"
                                     v-model="systemSettings.watermark_pos"
                                     class="input-modern"
+                                    :class="{ 'cursor-not-allowed opacity-60': hasPublicImageDomain }"
+                                    :disabled="hasPublicImageDomain"
                                     @change="handleSelectChange('watermark_pos', systemSettings.watermark_pos)"
                                 >
                                     <option value="" disabled>请选择图片水印位置</option>
@@ -241,6 +277,8 @@
                                     v-model="systemSettings.referer_white_list"
                                     type="password"
                                     class="input-modern min-h-[112px] leading-6"
+                                    :class="{ 'cursor-not-allowed opacity-60': hasPublicImageDomain }"
+                                    :disabled="hasPublicImageDomain"
                                     placeholder="Referer来源白名单，多个以英文逗号分隔"
                                     @blur="handleFieldBlur('referer_white_list', systemSettings.referer_white_list)"
                                     rows="4"
@@ -250,6 +288,9 @@
                                     1. 仅需填写域名（支持主域名），多个以英文逗号分隔；<br>
                                     2. 无需填写协议（http://），无需填写端口（:80）；<br>
                                     3. 如果开启了来源白名单，那么仅能从这些来源访问图片资源（直接打开不受限制）
+                                </div>
+                                <div v-if="hasPublicImageDomain" class="field-hint text-amber-600 dark:text-amber-300">
+                                    已配置图片直链域名，直接访问不会经过系统代理，来源白名单不会生效。
                                 </div>
                             </div>
 
@@ -521,13 +562,19 @@
                             <div class="setting-row">
                                 <div>
                                     <p class="setting-row-title">开启图片水印</p>
-                                    <p class="setting-row-hint">新上传的图片自动添加水印，历史图片不会补加。</p>
+                                    <p class="setting-row-hint">
+                                        {{ hasPublicImageDomain ? '已配置图片直链域名，图片水印不会生效。' : '新上传的图片自动添加水印，历史图片不会补加。' }}
+                                    </p>
                                 </div>
-                                <label class="relative inline-flex cursor-pointer items-center self-end md:self-center">
+                                <label
+                                    class="relative inline-flex items-center self-end md:self-center"
+                                    :class="hasPublicImageDomain ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'"
+                                >
                                     <input 
                                         type="checkbox" 
                                         v-model="systemSettings.watermark_enable"
                                         class="sr-only peer"
+                                        :disabled="hasPublicImageDomain"
                                         @change="handleSwitchChange('watermark_enable', systemSettings.watermark_enable)"
                                     >
                                     <div class="switch-track"></div>
@@ -537,12 +584,17 @@
                             <div class="setting-row">
                                 <div>
                                     <p class="setting-row-title">开启来源白名单</p>
+                                    <p v-if="hasPublicImageDomain" class="setting-row-hint">已配置图片直链域名，直接访问不会经过系统代理。</p>
                                 </div>
-                                <label class="relative inline-flex cursor-pointer items-center self-end md:self-center">
+                                <label
+                                    class="relative inline-flex items-center self-end md:self-center"
+                                    :class="hasPublicImageDomain ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'"
+                                >
                                     <input 
                                         type="checkbox" 
                                         v-model="systemSettings.referer_white_enable"
                                         class="sr-only peer"
+                                        :disabled="hasPublicImageDomain"
                                         @change="handleSwitchChange('referer_white_enable', systemSettings.referer_white_enable)"
                                     >
                                     <div class="switch-track"></div>
@@ -591,7 +643,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, reactive } from 'vue'
+import { ref, onMounted, reactive, computed } from 'vue'
 import message from '@/utils/message.js'
 // 存储相关
 const presetBuckets = ref([
@@ -632,10 +684,68 @@ const systemSettings = reactive({
     max_file_size: 10485760,
     allowed_types: 'image/jpeg,image/png,image/gif,image/webp,image/svg+xml',
     default_path: '/uploads/{year}/{moon}',
-    file_name: '{random}'
+    file_name: '{random}',
+    public_image_domain: ''
 })
 
 const updateSetting = reactive({})
+const publicDomainStorageTypes = ['s3', 'r2']
+const publicDomainAffectedSettings = [
+    'watermark_enable',
+    'watermark_text',
+    'watermark_size',
+    'watermark_color',
+    'watermark_opac',
+    'watermark_pos',
+    'referer_white_enable',
+    'referer_white_list'
+]
+
+const currentDefaultBucket = computed(() => {
+    return presetBuckets.value.find(bucket => String(bucket.id) === String(systemSettings.default_storage))
+})
+
+const supportsPublicImageDomain = computed(() => {
+    return publicDomainStorageTypes.includes(currentDefaultBucket.value?.type)
+})
+
+const hasPublicImageDomain = computed(() => {
+    return String(systemSettings.public_image_domain || '').trim() !== ''
+})
+
+const publicImageDomainUnavailable = computed(() => {
+    return !supportsPublicImageDomain.value
+})
+
+const publicImageDomainHint = computed(() => {
+    if (!supportsPublicImageDomain.value) {
+        return '当前默认存储不支持图片直链域名，仅 S3/R2 存储可用。'
+    }
+    if (hasPublicImageDomain.value) {
+        return '启用后图片链接将直接使用该域名，图片水印文本、来源白名单等依赖系统代理的功能不会生效。'
+    }
+    return '填写 S3/R2 绑定的直链域名后，返回给用户的图片链接会直接使用该域名。'
+})
+
+const bucketSupportsPublicImageDomain = (bucketId) => {
+    const bucket = presetBuckets.value.find(item => String(item.id) === String(bucketId))
+    return publicDomainStorageTypes.includes(bucket?.type)
+}
+
+const disabledByPublicImageDomain = (key) => {
+    return hasPublicImageDomain.value && publicDomainAffectedSettings.includes(key)
+}
+
+const normalizePublicImageDomain = (value) => {
+    let domain = String(value || '').trim()
+    if (domain === '') {
+        return ''
+    }
+    if (!domain.includes('://')) {
+        domain = `https://${domain}`
+    }
+    return domain.replace(/\/+$/, '')
+}
 
 // 加载状态
 const isUpdating = ref(false)
@@ -717,7 +827,7 @@ const getBucketsList = async () => {
     }
   } catch (error) {
     console.error('获取存储列表失败:', error);
-    Message.error(error.message || '获取存储列表失败');
+    message.error(error.message || '获取存储列表失败');
   }
 };
 
@@ -739,6 +849,12 @@ const generate32BitTokenMixCase = () => {
 
 // 开关状态变更统一处理方法
 const handleSwitchChange = (key, value) => {
+    if (disabledByPublicImageDomain(key)) {
+        message.warning('已配置图片直链域名，该设置不会生效')
+        systemSettings[key] = updateSetting[key]
+        return
+    }
+
     if (key == "start_api") {
         if (systemSettings.api_token === '' && !systemSettings.api_token_configured) {
             message.warning('请先填写API Token')
@@ -766,6 +882,24 @@ const handleSwitchChange = (key, value) => {
 
 // 输入框失去焦点处理
 const handleFieldBlur = (key, value) => {
+    if (disabledByPublicImageDomain(key)) {
+        message.warning('已配置图片直链域名，该设置不会生效')
+        systemSettings[key] = updateSetting[key]
+        return
+    }
+
+    if (key === 'public_image_domain') {
+        const normalizedValue = normalizePublicImageDomain(value)
+        systemSettings.public_image_domain = normalizedValue
+        value = normalizedValue
+
+        if (publicImageDomainUnavailable.value) {
+            message.warning('当前默认存储不支持图片直链域名')
+            systemSettings.public_image_domain = updateSetting.public_image_domain || ''
+            return
+        }
+    }
+
     if (key == 'tg_bot_token' || key == 'tg_receivers') {
         const isBotTokenEmpty = systemSettings.tg_bot_token === '' || systemSettings.tg_bot_token === null;
         if ((isBotTokenEmpty && !systemSettings.tg_bot_token_configured) || systemSettings.tg_receivers === '') {
@@ -780,7 +914,7 @@ const handleFieldBlur = (key, value) => {
             }
         }
     }
-    if (value === '' || value === updateSetting[key]) {
+    if ((value === '' && key !== 'public_image_domain') || value === updateSetting[key]) {
         return
     }
     if (key == 'api_token' && value === '') {
@@ -796,6 +930,18 @@ const handleFieldBlur = (key, value) => {
 
 // 下拉框变更处理
 const handleSelectChange = (key, value) => {
+    if (key === 'default_storage' && hasPublicImageDomain.value && !bucketSupportsPublicImageDomain(value)) {
+        message.warning('图片直链域名仅支持 S3/R2 存储，请先清空该配置')
+        systemSettings.default_storage = updateSetting.default_storage
+        return
+    }
+
+    if (disabledByPublicImageDomain(key)) {
+        message.warning('已配置图片直链域名，该设置不会生效')
+        systemSettings[key] = updateSetting[key]
+        return
+    }
+
     saveSetting(key, value)
 }
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -62,8 +62,8 @@
                                     v-model="systemSettings.public_image_domain"
                                     type="text"
                                     class="input-modern"
-                                    :class="{ 'cursor-not-allowed opacity-60': publicImageDomainUnavailable }"
-                                    :disabled="publicImageDomainUnavailable"
+                                    :class="{ 'cursor-not-allowed opacity-60': publicImageDomainInputDisabled }"
+                                    :disabled="publicImageDomainInputDisabled"
                                     placeholder="例如 https://img.example.com"
                                     @blur="handleFieldBlur('public_image_domain', systemSettings.public_image_domain)"
                                 />
@@ -717,6 +717,10 @@ const publicImageDomainUnavailable = computed(() => {
     return !supportsPublicImageDomain.value
 })
 
+const publicImageDomainInputDisabled = computed(() => {
+    return publicImageDomainUnavailable.value && !hasPublicImageDomain.value
+})
+
 const publicImageDomainHint = computed(() => {
     if (!supportsPublicImageDomain.value) {
         return '当前默认存储不支持图片直链域名，仅 S3/R2 存储可用。'
@@ -893,7 +897,7 @@ const handleFieldBlur = (key, value) => {
         systemSettings.public_image_domain = normalizedValue
         value = normalizedValue
 
-        if (publicImageDomainUnavailable.value) {
+        if (publicImageDomainUnavailable.value && normalizedValue !== '') {
             message.warning('当前默认存储不支持图片直链域名')
             systemSettings.public_image_domain = updateSetting.public_image_domain || ''
             return


### PR DESCRIPTION
为 S3/R2 存储增加图片直链域名配置，
上传、列表、详情、随机图和通知会返回直链地址，
数据库仍保存相对对象路径。

启用后会禁用水印和来源白名单等代理相关功能，
并提示用户先清空图片直链域名再修改这些设置。